### PR TITLE
Include src directory to paths search by compiler

### DIFF
--- a/compiler/protoc_ada.gpr
+++ b/compiler/protoc_ada.gpr
@@ -12,7 +12,7 @@ project Protoc_Ada is
 
 
    package Compiler is
-      for Switches ("c++") use ("-O2", "-Wall");
+      for Switches ("c++") use ("-O2", "-Wall", "-I" & "src");
    end Compiler;
 
    package Install is


### PR DESCRIPTION
This is to prevent error:
file not found with <angled> include; use "quotes" instead